### PR TITLE
fix TransferState inject signature

### DIFF
--- a/src/transfer-state.ts
+++ b/src/transfer-state.ts
@@ -42,7 +42,7 @@ export class TransferState {
     Object.keys(obj).forEach((key: string) => this.set(key, obj[key]));
   }
 
-  inject(): void {}
+  inject(location?: string): void {}
 }
 
 


### PR DESCRIPTION
when invoking `TransferState.inject` with `'head'` parameter in ServerTransferStateModule, compilation fail because `inject` do not accept parameters.

Since `inject(): void {}` is here to define the method overwritten in ServerTransferState, it should be replaced by `inject(location: string): void {}` 